### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Build and Release.yml
+++ b/.github/workflows/Build and Release.yml
@@ -1,4 +1,6 @@
 name: Build and Release
+permissions:
+  contents: read
 
 on:
   push:
@@ -74,6 +76,8 @@ jobs:
   release:
     name: Release Setup
     needs: build
+    permissions:
+      contents: write
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Shaneosaure/LBM_python_viewer/security/code-scanning/3](https://github.com/Shaneosaure/LBM_python_viewer/security/code-scanning/3)

The best fix is to add a `permissions` block to the workflow that follows the principle of least privilege. Since the workflow contains two jobs (`build` and `release`), and only the `release` job performs GitHub release write operations, the minimal permissions can be set at the root as `contents: read`. Then, in the `release` job, a job-level `permissions` block should explicitly grant `contents: write` to allow creation of releases and uploading assets. If your workflow also requires scope for `packages` or other resources, you may add those with appropriate minimum access (but from the shown code, only `contents` appears necessary).

Specifically, the following changes should be made:
- At the top level of the workflow (`.github/workflows/Build and Release.yml`), immediately below the `name:` line (and before `on:`), insert:
  ```yaml
  permissions:
    contents: read
  ```
- In the `release` job definition (after line 75, before 76: `needs: build`), insert a job-level `permissions` block:
  ```yaml
    permissions:
      contents: write
  ```
This ensures routines unrelated to releases have only read permission, while the release job can write release-related assets.

No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
